### PR TITLE
Add dotenv dependency in order to allow config/default.js to read values

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 .DS_Store
 .vscode
 
+#Nodejs .env Vars
+.env
+
 # Logs
 logs
 *.log

--- a/config/default.js
+++ b/config/default.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const dotenv = require('dotenv');
+dotenv.config();
+
 module.exports = {
 
   log: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -669,6 +669,11 @@
         "esutils": "^2.0.2"
       }
     },
+    "dotenv": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-10.0.0.tgz",
+      "integrity": "sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q=="
+    },
     "ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   "dependencies": {
     "co-body": "6.1.0",
     "config": "3.3.6",
+    "dotenv": "^10.0.0",
     "koa": "2.13.1",
     "koa-ejs": "4.3.0",
     "koa-locales": "1.12.0",


### PR DESCRIPTION
config/default.js tries to read values from .env files but it's missing the dotenv npm package. This fix will add the dotenv package and needed config. 


for example:
```
  mongo: {
    uri: process.env.MONGO_URI,
    user: process.env.MONGO_USER,
    pass: process.env.MONGO_PASS
  },
```
