### PR TITLE
Correct wrong wording

### DIFF
--- a/src/view/footer.html
+++ b/src/view/footer.html
@@ -1,7 +1,7 @@
 <footer class="footer">
   <nav>
     <ul>
-      <li><a target="_blank" href="https://www.mailvelope.com/imprint">Imprint</a></li> |
+      <li><a target="_blank" href="https://www.mailvelope.com/imprint">Impressum</a></li> |
       <li><a target="_blank" href="https://www.mailvelope.com/privacy-service">Privacy</a></li>
     </ul>
   </nav>


### PR DESCRIPTION
Imprint is a false friend and should be "legal" or the German "Impressum".