### PR TITLE
Add support for Web Key Directory (version 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,13 +50,38 @@ The HKP APIs are not documented here. Please refer to the [HKP specification](ht
 
 #### Accepted `options` parameters
 * mr
+* wkd
 
+### Web Key Directory support
+
+Web Key Directory support can be enabled by adding a rewrite rule to web server
+configured as a reverse proxy.
+
+Example configuration for caddy webserver (for example.com domain),
+
+```
+openpgpkey.example.com {
+	header /.well-known/openpgpkey/puri.sm/policy Content-Type text/plain
+        respond /.well-known/openpgpkey/puri.sm/policy `protocol-version 5`
+        route /.well-known/openpgpkey/example.com/hu/* {
+                rewrite * /pks/lookup?op=get&{query}%40example.com&options=mr
+                reverse_proxy localhost:3000
+        }
+}
+
+openpgpkey.example.com DNS records should be pointing to the mailvelope
+keyserver instance.
+```
 #### Usage example with GnuPG
 
 ```
 gpg --keyserver hkps://keys.mailvelope.com --search  info@mailvelope.com
 ```
 
+If Web Key Directory is enabled,
+```
+gpg --locate-keys  info@mailvelope.com
+```
 ## REST API
 
 ### Lookup a key

--- a/src/route/hkp.js
+++ b/src/route/hkp.js
@@ -89,7 +89,14 @@ class HKP {
     if (!['get', 'index', 'vindex'].includes(params.op)) {
       throw Boom.notImplemented('Method not implemented');
     }
-    this.parseSearch(query.search, params);
+    let searchString = query.search;
+/**
+ * Search string for Web Key Directory lookups is l
+ */
+    if (query.l) {
+      searchString = query.l;
+    }
+    this.parseSearch(searchString, params);
     if (!params.keyId && !params.fingerprint && !params.email) {
       throw Boom.badRequest('Invalid search parameter');
     }


### PR DESCRIPTION
This simplifies #146 (Fixes #121)

- no need to generate, store and search for wkd hash (since local part of email is passed as a query string)
- no need to dearmor the keys (gpg and thunderbird accepts ascii armored keys)